### PR TITLE
Allow adding tags for SLOs via list, not just a map. 

### DIFF
--- a/modules/slo/metric_slo.tf
+++ b/modules/slo/metric_slo.tf
@@ -79,6 +79,6 @@ resource "datadog_monitor" "metric_slo_alert" {
   #     key: null
   tags = try(tolist(each.value.slo.tags), null) != null ? try(tolist(each.value.slo.tags), null) : [
     # If the user has supplied a map of tags, use it. Otherwise, use the default tags if enabled.
-    for tagk, tagv in try(tomap(each.value.tags), var.default_tags_enabled ? module.this.tags : {}) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
+    for tagk, tagv in try(tomap(each.value.slo.tags), var.default_tags_enabled ? module.this.tags : {}) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
   ]
 }

--- a/modules/slo/metric_slo.tf
+++ b/modules/slo/metric_slo.tf
@@ -48,8 +48,9 @@ resource "datadog_service_level_objective" "metric_slo" {
   # If a key is supplied without a value (null), it will render "key" as a tag
   #   tags:
   #     key: null
-  tags = [
-    for tagk, tagv in lookup(each.value, "tags", module.this.tags) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
+  tags = try(tolist(each.value.tags), null) != null ? try(tolist(each.value.tags), null) : [
+    # If the user has supplied a map of tags, use it. Otherwise, use the default tags if enabled.
+    for tagk, tagv in try(tomap(each.value.tags), var.default_tags_enabled ? module.this.tags : {}) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
   ]
 }
 
@@ -76,7 +77,8 @@ resource "datadog_monitor" "metric_slo_alert" {
   # If a key is supplied without a value (null), it will render "key" as a tag
   #   tags:
   #     key: null
-  tags = [
-    for tagk, tagv in lookup(each.value.slo, "tags", module.this.tags) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
+  tags = try(tolist(each.value.slo.tags), null) != null ? try(tolist(each.value.slo.tags), null) : [
+    # If the user has supplied a map of tags, use it. Otherwise, use the default tags if enabled.
+    for tagk, tagv in try(tomap(each.value.tags), var.default_tags_enabled ? module.this.tags : {}) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
   ]
 }

--- a/modules/slo/monitor_slo.tf
+++ b/modules/slo/monitor_slo.tf
@@ -48,7 +48,8 @@ resource "datadog_service_level_objective" "monitor_slo" {
   # If a key is supplied without a value (null), it will render "key" as a tag
   #   tags:
   #     key: null
-  tags = [
-    for tagk, tagv in lookup(each.value, "tags", module.this.tags) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
+  tags = try(tolist(each.value.tags), null) != null ? try(tolist(each.value.tags), null) : [
+    # If the user has supplied a map of tags, use it. Otherwise, use the default tags if enabled.
+    for tagk, tagv in try(tomap(each.value.tags), var.default_tags_enabled ? module.this.tags : {}) : (tagv != null ? format("%s:%s", tagk, tagv) : tagk)
   ]
 }

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -14,3 +14,13 @@ variable "alert_tags_separator" {
   description = "Separator for the alert tags. All strings from the `alert_tags` variable will be joined into one string using the separator and then added to the alert message"
   default     = "\n"
 }
+
+variable "default_tags_enabled" {
+  type        = bool
+  description = <<-EOT
+    If true, monitors without `tags` in their definitions will have tags
+    from `null-label` added to them. Note that even an empty `list` or `map` of tags in
+    the monitor definition will keep the default tags from being added.
+    EOT
+  default     = true
+}


### PR DESCRIPTION



## what
This allows the ability for people to keep tag usage consistent between the monitor module and the SLO module.  It felt a bit disjointed in how you would supply tags for one (list or map) vs requiring just map for SLOs. This should help bridge that gap.

ie:
  tags:
    - "testing:test"

## why

Ran into this inconsistency while setting tags for an SLO that was going to match up with a monitor.
